### PR TITLE
feat(WeekDropdown): Close dropdown with `Escape` & on click outside

### DIFF
--- a/src/private/components/weekDropdown.jsx
+++ b/src/private/components/weekDropdown.jsx
@@ -32,13 +32,13 @@ export default function WeekDropdown({ buttonLabel }) {
 
   useEffect(() => {
     const handleWindowClick = (event) => {
-      console.log('root', event.currentTarget);
-      if (open && !event.target.contains(rootRef.current)) {
+      if (!rootRef.current.contains(event.target)) {
         setOpen(false);
       }
     };
     window.addEventListener('click', handleWindowClick, true);
-  }, [open]);
+    return () => window.removeEventListener('click', handleWindowClick, true);
+  }, []);
 
   return (
     <div
@@ -51,7 +51,7 @@ export default function WeekDropdown({ buttonLabel }) {
         aria-expanded={open}
         aria-haspopup="true"
         className={styles.dropdownButton}
-        // ref={buttonElementRef}
+        ref={buttonElementRef}
         onClick={() => setOpen((prev) => !prev)}
       >
         {buttonLabel}


### PR DESCRIPTION
## Summary
This PR builds on #38 by adding some more expected behavior: when the user presses `Escape` inside the `<WeekDropdown />` component, or clicks somewhere outside of `<WeekDropdown />`, we want to be sure that the dropdown closes.

Paired with [Lewis (@WizardOfWhimsical)](https://github.com/WizardOfWhimsical) to get this done. Can't tag him directly since he's not a collaborator.